### PR TITLE
Add map to store conversationId per channel

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -11,11 +11,11 @@ import (
 )
 
 type Bot struct {
-	session        *discordgo.Session
-	app            *app.App
-	ctx            context.Context
-	mu             sync.Mutex
-	conversationId string
+	session         *discordgo.Session
+	app             *app.App
+	ctx             context.Context
+	mu              sync.Mutex
+	conversationIds map[string]string
 }
 
 // BotInfo struct to hold bot's username and avatar URL
@@ -26,7 +26,8 @@ type BotInfo struct {
 
 func NewBot(app *app.App) *Bot {
 	return &Bot{
-		app: app,
+		app:             app,
+		conversationIds: make(map[string]string),
 	}
 }
 func (b *Bot) Startup(ctx context.Context) {


### PR DESCRIPTION
## 概要
各Discordチャンネルの会話ID (conversationId) を管理するためのマップを導入し、messageHandler関数を更新しました。

## 変更内容
1. Bot構造体にconversationIdsマップを追加し、初期化時に初期化するようにしました。
2. messageHandler関数を修正し、各チャンネルのconversationIdをマップから取得・保存するようにしました。

## 確認事項
- [x] 各チャンネルごとにconversationIdが正しく保存され、取得できることを確認しました。
- [x] メッセージ送信時に適切なconversationIdが使用されることを確認しました。
- [x] エラーなく動作することを確認しました。

